### PR TITLE
Remove Internal Elixir API Usage in production code

### DIFF
--- a/lib/mix_dependency_submission/util.ex
+++ b/lib/mix_dependency_submission/util.ex
@@ -30,10 +30,19 @@ defmodule MixDependencySubmission.Util do
   end
 
   @spec on_clean_slate(fun :: (-> result)) :: result when result: term()
-  defp on_clean_slate(fun) do
-    # Internal API :(
-    # TODO: Check with the Elixir Project about exposing this...
-    Mix.ProjectStack.on_clean_slate(fun)
+  defp on_clean_slate(fun)
+
+  case Mix.env() do
+    env when env in [:dev, :test] ->
+      defp on_clean_slate(fun) do
+        # This is an internal API that we need to call if the exection is run
+        # using mix (eg `mix test` / `mix mix_depdendency_submission`).
+        # Since it is not part of the production build, this is acceptable.
+        Mix.ProjectStack.on_clean_slate(fun)
+      end
+
+    _env ->
+      defp on_clean_slate(fun), do: fun.()
   end
 
   @spec with_ignored_module_conflicts(fun :: (-> result)) :: result when result: term()


### PR DESCRIPTION
Fixes #92

`on_clean_slate` is only required if the tool itself is already executed in `mix`. (eg `mix test` etc.)

For productive use, this is not required.

While using internal function in the development environment is still not optimal, that's acceptable.