### PR TITLE
Fix MixFile strategy for sparse git dependencies

### DIFF
--- a/lib/mix_dependency_submission/fetcher/mix_file.ex
+++ b/lib/mix_dependency_submission/fetcher/mix_file.ex
@@ -53,6 +53,16 @@ defmodule MixDependencySubmission.Fetcher.MixFile do
 
   defp normalize_dep({app, requirement, opts})
        when is_atom(app) and (is_binary(requirement) or is_nil(requirement)) and is_list(opts) do
+    bin_app = Atom.to_string(app)
+
+    dest = Path.join(Mix.Project.deps_path(), bin_app)
+    build = Path.join([Mix.Project.build_path(), "lib", bin_app])
+
+    opts =
+      opts
+      |> Keyword.put(:dest, dest)
+      |> Keyword.put(:build, build)
+
     {scm, opts} =
       Enum.find_value(Mix.SCM.available(), {nil, opts}, fn scm ->
         case scm.accepts_options(app, opts) do

--- a/test/fixtures/app_locked/mix.exs
+++ b/test/fixtures/app_locked/mix.exs
@@ -8,7 +8,9 @@ defmodule AppNameToReplace.MixProject do
       deps: [
         {:credo, "~> 1.7"},
         {:mime, "~> 2.0"},
-        {:expo, github: "elixir-gettext/expo"}
+        {:expo, github: "elixir-gettext/expo"},
+        {:heroicons,
+         github: "tailwindlabs/heroicons", tag: "v2.1.5", sparse: "optimized", app: false, compile: false, depth: 1}
       ]
     ]
   end

--- a/test/fixtures/app_locked/mix.lock
+++ b/test/fixtures/app_locked/mix.lock
@@ -3,6 +3,7 @@
   "credo": {:hex, :credo, "1.7.0", "6119bee47272e85995598ee04f2ebbed3e947678dee048d10b5feca139435f75", [:mix], [{:bunt, "~> 0.2.1", [hex: :bunt, repo: "hexpm", optional: false]}, {:file_system, "~> 0.2.8", [hex: :file_system, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "6839fcf63d1f0d1c0f450abc8564a57c43d644077ab96f2934563e68b8a769d7"},
   "expo": {:git, "https://github.com/elixir-gettext/expo.git", "2ae85019d62288001bdc4a949d65bf650beee315", []},
   "file_system": {:hex, :file_system, "0.2.10", "fb082005a9cd1711c05b5248710f8826b02d7d1784e7c3451f9c1231d4fc162d", [:mix], [], "hexpm", "41195edbfb562a593726eda3b3e8b103a309b733ad25f3d642ba49696bf715dc"},
+  "heroicons": {:git, "https://github.com/tailwindlabs/heroicons.git", "ad0ad1f6d51bd64dcd67e363d2b2833a8de25154", [tag: "v2.1.5", sparse: "optimized", depth: 1]},
   "jason": {:hex, :jason, "1.4.0", "e855647bc964a44e2f67df589ccf49105ae039d4179db7f6271dfd3843dc27e6", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "79a3791085b2a0f743ca04cec0f7be26443738779d09302e01318f97bdb82121"},
   "mime": {:hex, :mime, "2.0.6", "8f18486773d9b15f95f4f4f1e39b710045fa1de891fada4516559967276e4dc2", [:mix], [], "hexpm", "c9945363a6b26d747389aac3643f8e0e09d30499a138ad64fe8fd1d13d9b153e"},
 }

--- a/test/mix_dependency_submission/fetcher/mix_file_test.exs
+++ b/test/mix_dependency_submission/fetcher/mix_file_test.exs
@@ -1,6 +1,7 @@
 defmodule MixDependencySubmission.Fetcher.MixFileTest do
   use MixDependencySubmission.FixtureCase, async: false
 
+  alias Mix.SCM.Git
   alias MixDependencySubmission.Fetcher.MixFile
   alias MixDependencySubmission.Util
 
@@ -14,20 +15,45 @@ defmodule MixDependencySubmission.Fetcher.MixFileTest do
         assert %{
                  credo: %{
                    scm: Hex.SCM,
-                   mix_dep: {:credo, "~> 1.7", [hex: "credo", repo: "hexpm"]},
+                   mix_dep: {:credo, "~> 1.7", [hex: "credo", build: _credo_build, dest: _credo_dest, repo: "hexpm"]},
                    scope: :runtime,
                    relationship: :direct
                  },
                  expo: %{
-                   scm: Mix.SCM.Git,
-                   mix_dep: {:expo, nil, [git: "https://github.com/elixir-gettext/expo.git", checkout: nil]},
+                   scm: Git,
+                   mix_dep:
+                     {:expo, nil,
+                      [
+                        git: "https://github.com/elixir-gettext/expo.git",
+                        checkout: _expo_checkout,
+                        build: _expo_build,
+                        dest: _expo_dest
+                      ]},
                    scope: :runtime,
                    relationship: :direct
                  },
                  mime: %{
                    scm: Hex.SCM,
-                   mix_dep: {:mime, "~> 2.0", [hex: "mime", repo: "hexpm"]},
+                   mix_dep: {:mime, "~> 2.0", [hex: "mime", build: _mime_build, dest: _mime_dest, repo: "hexpm"]},
                    scope: :runtime,
+                   relationship: :direct
+                 },
+                 heroicons: %{
+                   scope: :runtime,
+                   scm: Git,
+                   mix_dep:
+                     {:heroicons, nil,
+                      [
+                        git: "https://github.com/tailwindlabs/heroicons.git",
+                        dest: _heroicons_dest,
+                        checkout: _heroicons_checkout,
+                        build: _heroicons_build,
+                        tag: "v2.1.5",
+                        sparse: "optimized",
+                        app: false,
+                        compile: false,
+                        depth: 1
+                      ]},
                    relationship: :direct
                  }
                } = MixFile.fetch()
@@ -40,7 +66,7 @@ defmodule MixDependencySubmission.Fetcher.MixFileTest do
       Util.in_project(app_path, fn _mix_module ->
         assert %{
                  credo: %{
-                   mix_dep: {:credo, "~> 1.7", [hex: "credo", repo: "hexpm"]},
+                   mix_dep: {:credo, "~> 1.7", [hex: "credo", build: _credo_build, dest: _credo_dest, repo: "hexpm"]},
                    relationship: :direct,
                    scm: Hex.SCM,
                    scope: :runtime
@@ -48,7 +74,7 @@ defmodule MixDependencySubmission.Fetcher.MixFileTest do
                  path_dep: %{
                    scope: :runtime,
                    scm: Mix.SCM.Path,
-                   mix_dep: {:path_dep, nil, [dest: "/tmp", path: "/tmp"]},
+                   mix_dep: {:path_dep, nil, [dest: "/tmp", build: _path_dep_build, path: "/tmp"]},
                    relationship: :direct
                  }
                } = MixFile.fetch()


### PR DESCRIPTION
Fixes #109 

`mix` sets some additional options before passing them to `scm.accepts_options/2`:
https://github.com/elixir-lang/elixir/blob/e967d58273795b3f03fe9a187e0e3ba4877ce997/lib/mix/lib/mix/dep/loader.ex#L178-L186

Doing the same now.