### PR TITLE
Bump `setup-beam` to support Ubuntu 26.04

### DIFF
--- a/.github/actions/setup-runtime-env/action.yml
+++ b/.github/actions/setup-runtime-env/action.yml
@@ -9,7 +9,7 @@ runs:
   using: "composite"
   steps:
     - name: "Setup BEAM"
-      uses: erlef/setup-beam@5304e04ea2b355f03681464e683d92e3b2f18451 # v1.18.2
+      uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
       id: setupBEAM
       with:
         version-file: .tool-versions


### PR DESCRIPTION
We pin `setup-beam` to its most recent version.